### PR TITLE
Minimal apache2 reverse proxy docker image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Beispiel Environment-Datei
+# Kopieren Sie diese Datei nach .env und passen Sie die Werte an
+
+# Timezone
+TZ=Europe/Berlin
+
+# Apache Ports (falls Standard-Ports bereits belegt sind)
+HTTP_PORT=80
+HTTPS_PORT=443
+
+# Container Name
+CONTAINER_NAME=apache-reverse-proxy
+
+# Network Name
+NETWORK_NAME=apache-proxy-network

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,33 @@
+# Logs
+logs/
+*.log
+
+# Let's Encrypt certificates (will be in Docker volume)
+letsencrypt/
+
+# Webroot temporary files
+webroot/*
+!webroot/.gitkeep
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Editor files
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# Backup files
+*.bak
+*.backup
+*.old
+
+# Docker override files
+docker-compose.override.yml
+
+# Environment files with secrets
+.env.local
+.env.production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,66 @@
+# Basis-Image: Ubuntu 22.04 LTS (minimal)
+FROM ubuntu:22.04
+
+# Environment Variables
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TZ=UTC
+
+# Update und Installation der benötigten Pakete
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    apache2 \
+    apache2-utils \
+    certbot \
+    python3-certbot-apache \
+    curl \
+    ca-certificates \
+    tzdata \
+    cron \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+# Apache Module aktivieren
+RUN a2enmod proxy \
+    && a2enmod proxy_http \
+    && a2enmod proxy_https \
+    && a2enmod ssl \
+    && a2enmod rewrite \
+    && a2enmod headers \
+    && a2enmod proxy_wstunnel \
+    && a2enmod proxy_connect
+
+# Verzeichnisse für Bind-Mounts erstellen
+RUN mkdir -p /etc/apache2/sites-available \
+    && mkdir -p /etc/apache2/sites-enabled \
+    && mkdir -p /etc/letsencrypt \
+    && mkdir -p /var/log/apache2 \
+    && mkdir -p /var/www/html
+
+# Standard Apache Konfiguration entfernen
+RUN rm -f /etc/apache2/sites-enabled/000-default.conf
+
+# Cron für Let's Encrypt Auto-Renewal
+RUN echo "0 0,12 * * * root certbot renew --quiet --no-self-upgrade --post-hook 'apache2ctl graceful'" > /etc/cron.d/certbot-renew \
+    && chmod 0644 /etc/cron.d/certbot-renew
+
+# Entrypoint-Skript kopieren
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+# Apache2 Foreground Mode konfigurieren
+ENV APACHE_RUN_USER www-data
+ENV APACHE_RUN_GROUP www-data
+ENV APACHE_LOG_DIR /var/log/apache2
+ENV APACHE_PID_FILE /var/run/apache2/apache2.pid
+ENV APACHE_RUN_DIR /var/run/apache2
+ENV APACHE_LOCK_DIR /var/lock/apache2
+
+# Ports
+EXPOSE 80 443
+
+# Health Check
+HEALTHCHECK --interval=30s --timeout=3s --start-period=40s --retries=3 \
+    CMD curl -f http://localhost/ || exit 1
+
+# Entrypoint
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["apache2ctl", "-D", "FOREGROUND"]

--- a/README.md
+++ b/README.md
@@ -1,0 +1,223 @@
+# Apache2 Reverse Proxy mit Let's Encrypt
+
+Dieses Docker-Image bietet einen Apache2 Reverse Proxy basierend auf Ubuntu 22.04 LTS mit integrierter Let's Encrypt Unterstützung.
+
+## Features
+
+- **Minimales Ubuntu 22.04 LTS** als Basis
+- **Apache2** mit allen wichtigen Proxy-Modulen
+- **Let's Encrypt** Integration mit automatischer Zertifikatserneuerung
+- **Bind-Mount** Unterstützung für alle Konfigurationsdateien
+- **Portainer** kompatibel
+- **Einfache Updates** ohne Konfigurationsverlust
+
+## Schnellstart
+
+### 1. Repository klonen
+
+```bash
+git clone <repository-url>
+cd apache-reverse-proxy
+```
+
+### 2. Konfiguration vorbereiten
+
+Die Apache-Konfiguration wird über Bind-Mounts eingebunden. Die Verzeichnisstruktur ist bereits vorbereitet:
+
+```
+config/
+├── sites-available/    # Verfügbare Site-Konfigurationen
+├── sites-enabled/      # Aktivierte Sites (Symlinks)
+├── conf-available/     # Zusätzliche Apache-Konfigurationen
+├── conf-enabled/       # Aktivierte Konfigurationen
+├── mods-available/     # Module-Konfigurationen
+└── mods-enabled/       # Aktivierte Module
+```
+
+### 3. Reverse Proxy konfigurieren
+
+1. Kopieren Sie eine der Beispielkonfigurationen:
+```bash
+cp config/sites-available/example-reverse-proxy.conf config/sites-available/meine-domain.conf
+```
+
+2. Passen Sie die Konfiguration an Ihre Bedürfnisse an (Domain, Backend-Server, etc.)
+
+3. Aktivieren Sie die Site:
+```bash
+cd config/sites-enabled/
+ln -s ../sites-available/meine-domain.conf .
+```
+
+### 4. Container starten
+
+Mit Docker Compose:
+```bash
+docker-compose up -d
+```
+
+Oder direkt mit Docker:
+```bash
+docker build -t apache-reverse-proxy .
+docker run -d \
+  --name apache-reverse-proxy \
+  -p 80:80 \
+  -p 443:443 \
+  -v $(pwd)/config/sites-available:/etc/apache2/sites-available:ro \
+  -v $(pwd)/config/sites-enabled:/etc/apache2/sites-enabled:ro \
+  -v letsencrypt:/etc/letsencrypt \
+  -v $(pwd)/logs:/var/log/apache2 \
+  apache-reverse-proxy
+```
+
+## Let's Encrypt Zertifikate
+
+### Neues Zertifikat erstellen
+
+1. Stellen Sie sicher, dass Ihre Domain auf den Server zeigt
+2. Führen Sie im Container aus:
+```bash
+docker exec -it apache-reverse-proxy certbot --apache -d example.com -d www.example.com
+```
+
+### Automatische Erneuerung
+
+Die Zertifikate werden automatisch alle 12 Stunden überprüft und bei Bedarf erneuert.
+
+### Manualle Erneuerung
+
+```bash
+docker exec -it apache-reverse-proxy certbot renew
+```
+
+## Portainer Integration
+
+### Stack in Portainer einrichten
+
+1. Gehen Sie in Portainer zu "Stacks" → "Add stack"
+2. Wählen Sie "Repository" als Build-Methode
+3. Geben Sie die Repository-URL ein
+4. Setzen Sie `docker-compose.yml` als Compose-Pfad
+5. Konfigurieren Sie ggf. Environment-Variablen
+6. Deploy starten
+
+### Environment Variablen
+
+- `TZ`: Zeitzone (Standard: UTC)
+
+## Verzeichnisstruktur
+
+```
+.
+├── Dockerfile                  # Docker Image Definition
+├── docker-compose.yml         # Docker Compose Konfiguration
+├── docker-entrypoint.sh       # Startskript
+├── README.md                  # Diese Datei
+├── config/                    # Apache Konfigurationen (Bind-Mount)
+│   ├── sites-available/       # Verfügbare Sites
+│   ├── sites-enabled/         # Aktivierte Sites
+│   ├── conf-available/        # Verfügbare Configs
+│   ├── conf-enabled/          # Aktivierte Configs
+│   ├── mods-available/        # Verfügbare Module
+│   └── mods-enabled/          # Aktivierte Module
+├── logs/                      # Apache Logs
+└── webroot/                   # Webroot für Let's Encrypt
+```
+
+## Konfigurationsbeispiele
+
+### Einfacher Reverse Proxy
+
+```apache
+<VirtualHost *:80>
+    ServerName app.example.com
+    ProxyPass / http://backend-app:3000/
+    ProxyPassReverse / http://backend-app:3000/
+</VirtualHost>
+```
+
+### SSL mit Let's Encrypt
+
+Siehe `config/sites-available/ssl-reverse-proxy-template.conf` für eine vollständige Vorlage.
+
+### WebSocket Support
+
+```apache
+# WebSocket Upgrade
+RewriteEngine On
+RewriteCond %{HTTP:Upgrade} websocket [NC]
+RewriteCond %{HTTP:Connection} upgrade [NC]
+RewriteRule ^/?(.*) "ws://backend:8080/$1" [P,L]
+```
+
+## Updates
+
+### Image aktualisieren
+
+1. Neues Image bauen:
+```bash
+docker-compose build --no-cache
+```
+
+2. Container neu starten:
+```bash
+docker-compose down
+docker-compose up -d
+```
+
+Die Konfigurationen und Zertifikate bleiben durch die Bind-Mounts erhalten.
+
+### Apache/Ubuntu Updates
+
+Das Basis-Image verwendet Ubuntu 22.04 LTS. Für Sicherheitsupdates:
+
+```bash
+docker-compose pull
+docker-compose up -d
+```
+
+## Troubleshooting
+
+### Logs prüfen
+
+```bash
+# Container Logs
+docker-compose logs -f
+
+# Apache Error Logs
+tail -f logs/error.log
+
+# Apache Access Logs
+tail -f logs/access.log
+```
+
+### Konfiguration testen
+
+```bash
+docker exec -it apache-reverse-proxy apache2ctl configtest
+```
+
+### Let's Encrypt Probleme
+
+1. Prüfen Sie, ob Port 80 erreichbar ist
+2. Stellen Sie sicher, dass die Domain korrekt aufgelöst wird
+3. Überprüfen Sie die Logs:
+```bash
+docker exec -it apache-reverse-proxy tail -f /var/log/letsencrypt/letsencrypt.log
+```
+
+## Sicherheitshinweise
+
+- Halten Sie das Image regelmäßig aktuell
+- Verwenden Sie starke SSL-Konfigurationen (siehe Templates)
+- Beschränken Sie den Zugriff auf die Konfigurationsdateien
+- Aktivieren Sie Security Headers (in den Templates enthalten)
+- Überwachen Sie die Logs auf verdächtige Aktivitäten
+
+## Support
+
+Bei Problemen:
+1. Prüfen Sie die Logs
+2. Testen Sie die Apache-Konfiguration
+3. Stellen Sie sicher, dass alle Ports frei sind
+4. Überprüfen Sie die DNS-Einstellungen für Let's Encrypt

--- a/config/sites-available/example-reverse-proxy.conf
+++ b/config/sites-available/example-reverse-proxy.conf
@@ -1,0 +1,48 @@
+# Beispiel Reverse Proxy Konfiguration
+# Diese Datei nach /config/sites-available/ kopieren und anpassen
+# Dann einen symbolischen Link in /config/sites-enabled/ erstellen
+
+<VirtualHost *:80>
+    ServerName example.com
+    ServerAlias www.example.com
+    
+    # Redirect to HTTPS
+    RewriteEngine On
+    RewriteCond %{HTTPS} off
+    RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName example.com
+    ServerAlias www.example.com
+    
+    # SSL Configuration
+    SSLEngine on
+    SSLCertificateFile /etc/letsencrypt/live/example.com/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/example.com/privkey.pem
+    
+    # Security Headers
+    Header always set Strict-Transport-Security "max-age=31536000; includeSubDomains"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Frame-Options "SAMEORIGIN"
+    Header always set X-XSS-Protection "1; mode=block"
+    Header always set Referrer-Policy "strict-origin-when-cross-origin"
+    
+    # Proxy Settings
+    ProxyPreserveHost On
+    ProxyRequests Off
+    
+    # WebSocket Support
+    RewriteEngine On
+    RewriteCond %{HTTP:Upgrade} websocket [NC]
+    RewriteCond %{HTTP:Connection} upgrade [NC]
+    RewriteRule ^/?(.*) "ws://backend-server:8080/$1" [P,L]
+    
+    # Reverse Proxy to Backend
+    ProxyPass / http://backend-server:8080/
+    ProxyPassReverse / http://backend-server:8080/
+    
+    # Logging
+    ErrorLog ${APACHE_LOG_DIR}/example.com-error.log
+    CustomLog ${APACHE_LOG_DIR}/example.com-access.log combined
+</VirtualHost>

--- a/config/sites-available/ssl-reverse-proxy-template.conf
+++ b/config/sites-available/ssl-reverse-proxy-template.conf
@@ -1,0 +1,61 @@
+# SSL Reverse Proxy Template
+# Verwenden Sie diese Vorlage für neue SSL-gesicherte Reverse Proxy Hosts
+
+<VirtualHost *:80>
+    ServerName ${DOMAIN_NAME}
+    
+    # Let's Encrypt Webroot Verification
+    DocumentRoot /var/www/html
+    
+    <Location /.well-known/acme-challenge/>
+        Options None
+        Require all granted
+    </Location>
+    
+    # Redirect all other traffic to HTTPS
+    RewriteEngine On
+    RewriteCond %{REQUEST_URI} !^/\.well-known/acme-challenge/
+    RewriteRule ^(.*)$ https://%{HTTP_HOST}$1 [R=301,L]
+</VirtualHost>
+
+<VirtualHost *:443>
+    ServerName ${DOMAIN_NAME}
+    
+    # SSL Configuration
+    SSLEngine on
+    SSLProtocol -all +TLSv1.2 +TLSv1.3
+    SSLCipherSuite ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384
+    SSLHonorCipherOrder on
+    SSLCompression off
+    SSLSessionTickets off
+    
+    # Let's Encrypt Certificates
+    SSLCertificateFile /etc/letsencrypt/live/${DOMAIN_NAME}/fullchain.pem
+    SSLCertificateKeyFile /etc/letsencrypt/live/${DOMAIN_NAME}/privkey.pem
+    
+    # Security Headers
+    Header always set Strict-Transport-Security "max-age=63072000; includeSubDomains; preload"
+    Header always set X-Content-Type-Options "nosniff"
+    Header always set X-Frame-Options "DENY"
+    Header always set X-XSS-Protection "1; mode=block"
+    Header always set Referrer-Policy "no-referrer-when-downgrade"
+    Header always set Content-Security-Policy "default-src 'self' http: https: data: blob: 'unsafe-inline'"
+    Header always set Permissions-Policy "geolocation=(), microphone=(), camera=()"
+    
+    # Proxy Configuration
+    ProxyPreserveHost On
+    ProxyRequests Off
+    RequestHeader set X-Forwarded-Proto "https"
+    RequestHeader set X-Forwarded-Port "443"
+    
+    # Proxy to Backend
+    ProxyPass / ${BACKEND_URL}/
+    ProxyPassReverse / ${BACKEND_URL}/
+    
+    # Proxy Timeouts
+    ProxyTimeout 600
+    
+    # Logging
+    ErrorLog ${APACHE_LOG_DIR}/${DOMAIN_NAME}-error.log
+    CustomLog ${APACHE_LOG_DIR}/${DOMAIN_NAME}-access.log combined
+</VirtualHost>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,41 @@
+version: '3.8'
+
+services:
+  apache-reverse-proxy:
+    build: .
+    image: apache-reverse-proxy:latest
+    container_name: ${CONTAINER_NAME:-apache-reverse-proxy}
+    restart: unless-stopped
+    ports:
+      - "${HTTP_PORT:-80}:80"
+      - "${HTTPS_PORT:-443}:443"
+    volumes:
+      # Apache2 Konfiguration
+      - ./config/sites-available:/etc/apache2/sites-available:ro
+      - ./config/sites-enabled:/etc/apache2/sites-enabled:ro
+      - ./config/conf-available:/etc/apache2/conf-available:ro
+      - ./config/conf-enabled:/etc/apache2/conf-enabled:ro
+      - ./config/mods-available:/etc/apache2/mods-available:ro
+      - ./config/mods-enabled:/etc/apache2/mods-enabled:ro
+      
+      # Let's Encrypt Zertifikate (persistent)
+      - letsencrypt:/etc/letsencrypt
+      
+      # Apache2 Logs (optional)
+      - ./logs:/var/log/apache2
+      
+      # Webroot für Let's Encrypt Challenge (falls benötigt)
+      - ./webroot:/var/www/html
+    environment:
+      - TZ=${TZ:-Europe/Berlin}
+    networks:
+      - proxy-network
+
+volumes:
+  letsencrypt:
+    name: apache-letsencrypt
+
+networks:
+  proxy-network:
+    driver: bridge
+    name: ${NETWORK_NAME:-apache-proxy-network}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+echo "Starting Apache2 Reverse Proxy with Let's Encrypt support..."
+
+# Apache2 Verzeichnisse erstellen falls nicht vorhanden
+mkdir -p ${APACHE_RUN_DIR}
+mkdir -p ${APACHE_LOCK_DIR}
+mkdir -p ${APACHE_LOG_DIR}
+
+# Berechtigungen setzen
+chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} ${APACHE_LOG_DIR}
+chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /var/www/html
+
+# Prüfen ob sites-enabled leer ist
+if [ -z "$(ls -A /etc/apache2/sites-enabled)" ]; then
+    echo "Warnung: Keine Sites aktiviert. Bitte mounten Sie Ihre Konfigurationsdateien."
+    # Erstelle eine minimale Default-Konfiguration
+    cat > /etc/apache2/sites-enabled/000-default.conf <<EOF
+<VirtualHost *:80>
+    ServerAdmin webmaster@localhost
+    DocumentRoot /var/www/html
+    
+    ErrorLog \${APACHE_LOG_DIR}/error.log
+    CustomLog \${APACHE_LOG_DIR}/access.log combined
+    
+    <Directory /var/www/html>
+        Options Indexes FollowSymLinks
+        AllowOverride All
+        Require all granted
+    </Directory>
+</VirtualHost>
+EOF
+fi
+
+# Apache2 Konfiguration testen
+echo "Testing Apache2 configuration..."
+apache2ctl configtest
+
+# Cron für Let's Encrypt starten
+echo "Starting cron for Let's Encrypt auto-renewal..."
+service cron start
+
+# ServerName setzen falls nicht vorhanden
+if ! grep -q "^ServerName" /etc/apache2/apache2.conf; then
+    echo "ServerName localhost" >> /etc/apache2/apache2.conf
+fi
+
+# Execute CMD
+echo "Starting Apache2..."
+exec "$@"

--- a/scripts/generate-cert.sh
+++ b/scripts/generate-cert.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# Hilfsskript zum Generieren von Let's Encrypt Zertifikaten
+
+set -e
+
+# Prüfe ob Parameter übergeben wurden
+if [ $# -eq 0 ]; then
+    echo "Verwendung: $0 <domain> [zusätzliche-domains...]"
+    echo "Beispiel: $0 example.com www.example.com"
+    exit 1
+fi
+
+# Container Name
+CONTAINER_NAME="apache-reverse-proxy"
+
+# Prüfe ob Container läuft
+if ! docker ps | grep -q $CONTAINER_NAME; then
+    echo "Error: Container '$CONTAINER_NAME' läuft nicht!"
+    exit 1
+fi
+
+# Domains sammeln
+DOMAINS=""
+for domain in "$@"; do
+    DOMAINS="$DOMAINS -d $domain"
+done
+
+echo "Generiere Zertifikat für: $DOMAINS"
+echo "Bitte stellen Sie sicher, dass alle Domains auf diesen Server zeigen!"
+echo ""
+
+# Certbot ausführen
+docker exec -it $CONTAINER_NAME certbot --apache \
+    --non-interactive \
+    --agree-tos \
+    --email webmaster@${1} \
+    --no-eff-email \
+    $DOMAINS
+
+echo ""
+echo "Zertifikat wurde erfolgreich erstellt!"
+echo "Apache wurde automatisch neu konfiguriert."

--- a/webroot/.gitkeep
+++ b/webroot/.gitkeep
@@ -1,0 +1,1 @@
+# This file ensures the webroot directory is tracked by git


### PR DESCRIPTION
Adds a Dockerized Apache2 reverse proxy with Let's Encrypt support and bind-mounts for easy configuration and updates.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fca41a1-f335-4abf-9799-92a99066ea41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8fca41a1-f335-4abf-9799-92a99066ea41">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

