### PR TITLE
Fix apache module enabling error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Apache Module aktivieren
 RUN a2enmod proxy \
     && a2enmod proxy_http \
-    && a2enmod proxy_https \
     && a2enmod ssl \
     && a2enmod rewrite \
     && a2enmod headers \


### PR DESCRIPTION
Remove `a2enmod proxy_https` from the Dockerfile to fix the image build error.

---
<a href="https://cursor.com/background-agent?bcId=bc-f5f2d77e-f8ea-477b-987a-5d674c2f64c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f5f2d77e-f8ea-477b-987a-5d674c2f64c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

