### PR TITLE
Populate empty config volumes with initial files

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,15 @@ RUN mkdir -p /etc/apache2/sites-available \
 # Standard Apache Konfiguration entfernen
 RUN rm -f /etc/apache2/sites-enabled/000-default.conf
 
+# Defaults der Apache-Konfiguration für Seed-on-empty sichern
+RUN mkdir -p /opt/defaults/apache2 \
+    && cp -a /etc/apache2/sites-available /opt/defaults/apache2/ \
+    && cp -a /etc/apache2/sites-enabled /opt/defaults/apache2/ \
+    && cp -a /etc/apache2/conf-available /opt/defaults/apache2/ \
+    && cp -a /etc/apache2/conf-enabled /opt/defaults/apache2/ \
+    && cp -a /etc/apache2/mods-available /opt/defaults/apache2/ \
+    && cp -a /etc/apache2/mods-enabled /opt/defaults/apache2/
+
 # Cron für Let's Encrypt Auto-Renewal
 RUN echo "0 0,12 * * * root certbot renew --quiet --no-self-upgrade --post-hook 'apache2ctl graceful'" > /etc/cron.d/certbot-renew \
     && chmod 0644 /etc/cron.d/certbot-renew

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,12 +11,12 @@ services:
       - "${HTTPS_PORT:-443}:443"
     volumes:
       # Apache2 Konfiguration
-      - ./config/sites-available:/etc/apache2/sites-available:ro
-      - ./config/sites-enabled:/etc/apache2/sites-enabled:ro
-      - ./config/conf-available:/etc/apache2/conf-available:ro
-      - ./config/conf-enabled:/etc/apache2/conf-enabled:ro
-      - ./config/mods-available:/etc/apache2/mods-available:ro
-      - ./config/mods-enabled:/etc/apache2/mods-enabled:ro
+      - ./config/sites-available:/etc/apache2/sites-available
+      - ./config/sites-enabled:/etc/apache2/sites-enabled
+      - ./config/conf-available:/etc/apache2/conf-available
+      - ./config/conf-enabled:/etc/apache2/conf-enabled
+      - ./config/mods-available:/etc/apache2/mods-available
+      - ./config/mods-enabled:/etc/apache2/mods-enabled
       
       # Let's Encrypt Zertifikate (persistent)
       - letsencrypt:/etc/letsencrypt

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -euo pipefail
 
 echo "Starting Apache2 Reverse Proxy with Let's Encrypt support..."
 
@@ -12,18 +12,41 @@ mkdir -p ${APACHE_LOG_DIR}
 chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} ${APACHE_LOG_DIR}
 chown -R ${APACHE_RUN_USER}:${APACHE_RUN_GROUP} /var/www/html
 
-# Prüfen ob sites-enabled leer ist
-if [ -z "$(ls -A /etc/apache2/sites-enabled)" ]; then
-    echo "Warnung: Keine Sites aktiviert. Bitte mounten Sie Ihre Konfigurationsdateien."
-    # Erstelle eine minimale Default-Konfiguration
+# Seed-on-empty für Apache-Konfigurationsverzeichnisse bei Bind-Mounts
+seed_if_empty() {
+    local source_dir="$1"
+    local target_dir="$2"
+    if [ ! -d "$target_dir" ]; then
+        mkdir -p "$target_dir"
+    fi
+    if [ -z "$(ls -A "$target_dir" 2>/dev/null || true)" ]; then
+        echo "Initializing $target_dir from $source_dir ..."
+        # -a bewahrt Rechte/Links, der Punkt kopiert nur Inhalte, nicht das Verzeichnis selbst
+        cp -a "$source_dir"/. "$target_dir"/
+    else
+        echo "$target_dir not empty, leaving as-is."
+    fi
+}
+
+DEFAULTS_ROOT="/opt/defaults/apache2"
+seed_if_empty "$DEFAULTS_ROOT/sites-available" "/etc/apache2/sites-available"
+seed_if_empty "$DEFAULTS_ROOT/sites-enabled" "/etc/apache2/sites-enabled"
+seed_if_empty "$DEFAULTS_ROOT/conf-available" "/etc/apache2/conf-available"
+seed_if_empty "$DEFAULTS_ROOT/conf-enabled" "/etc/apache2/conf-enabled"
+seed_if_empty "$DEFAULTS_ROOT/mods-available" "/etc/apache2/mods-available"
+seed_if_empty "$DEFAULTS_ROOT/mods-enabled" "/etc/apache2/mods-enabled"
+
+# Falls nach Seeding noch keine Site aktiviert ist, minimale Default-Site erstellen
+if [ -z "$(ls -A /etc/apache2/sites-enabled 2>/dev/null || true)" ]; then
+    echo "No enabled sites found. Creating minimal default vhost..."
     cat > /etc/apache2/sites-enabled/000-default.conf <<EOF
 <VirtualHost *:80>
     ServerAdmin webmaster@localhost
     DocumentRoot /var/www/html
-    
-    ErrorLog \${APACHE_LOG_DIR}/error.log
-    CustomLog \${APACHE_LOG_DIR}/access.log combined
-    
+
+    ErrorLog ${APACHE_LOG_DIR}/error.log
+    CustomLog ${APACHE_LOG_DIR}/access.log combined
+
     <Directory /var/www/html>
         Options Indexes FollowSymLinks
         AllowOverride All


### PR DESCRIPTION
Implement seed-on-empty logic for Apache configuration bind mounts to pre-populate empty host directories with default files.

When bind-mounting Apache configuration directories, an empty host directory would override the container's default files. This change ensures that if a bind-mounted directory is empty, it's automatically populated with the image's default configuration, providing a starting point for customization.

---
<a href="https://cursor.com/background-agent?bcId=bc-155fdc70-26c8-46e7-ad97-c33a8319e29d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-155fdc70-26c8-46e7-ad97-c33a8319e29d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

