### PR TITLE
Configure docker container for ipv6

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,10 @@
+# Interface on the host connected to your LAN (e.g. eth0, enp3s0)
+PARENT_IFACE=eth0
+# macvlan network name override (optional)
+IPV6_LAN_NETWORK_NAME=apache-lan-ipv6
+# Existing compose variables
+CONTAINER_NAME=apache-reverse-proxy
+NETWORK_NAME=apache-proxy-network
+HTTP_PORT=80
+HTTPS_PORT=443
+TZ=Europe/Berlin

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,16 @@ services:
       - ./webroot:/var/www/html
     environment:
       - TZ=${TZ:-Europe/Berlin}
+    sysctls:
+      net.ipv6.conf.all.disable_ipv6: 0
+      net.ipv6.conf.default.disable_ipv6: 0
+      net.ipv6.conf.all.accept_ra: 2
+      net.ipv6.conf.default.accept_ra: 2
+      net.ipv6.conf.all.autoconf: 1
+      net.ipv6.conf.default.autoconf: 1
     networks:
       - proxy-network
+      - lan-ipv6
 
 volumes:
   letsencrypt:
@@ -39,3 +47,8 @@ networks:
   proxy-network:
     driver: bridge
     name: ${NETWORK_NAME:-apache-proxy-network}
+  lan-ipv6:
+    driver: macvlan
+    name: ${IPV6_LAN_NETWORK_NAME:-apache-lan-ipv6}
+    driver_opts:
+      parent: ${PARENT_IFACE:-eth0}


### PR DESCRIPTION
Add macvlan network and IPv6 sysctls to allow the container to obtain an IPv6 address from the router.

---
<a href="https://cursor.com/background-agent?bcId=bc-287bd5e4-df02-4488-a74d-dad075b1bde6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-287bd5e4-df02-4488-a74d-dad075b1bde6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

