### PR TITLE
Configure container for macvlan and ipv6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     tzdata \
     cron \
+    isc-dhcp-client \
     nano \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,10 @@ services:
       - ./webroot:/var/www/html
     environment:
       - TZ=${TZ:-Europe/Berlin}
+      - ENABLE_DHCPV6=${ENABLE_DHCPV6:-true}
+      - DHCPV6_IFACE=${DHCPV6_IFACE:-}
+    cap_add:
+      - NET_ADMIN
     sysctls:
       net.ipv6.conf.all.disable_ipv6: 0
       net.ipv6.conf.default.disable_ipv6: 0
@@ -48,7 +52,5 @@ networks:
     driver: bridge
     name: ${NETWORK_NAME:-apache-proxy-network}
   lan-ipv6:
-    driver: macvlan
+    external: true
     name: ${IPV6_LAN_NETWORK_NAME:-apache-lan-ipv6}
-    driver_opts:
-      parent: ${PARENT_IFACE:-eth0}

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -64,6 +64,20 @@ apache2ctl configtest
 echo "Starting cron for Let's Encrypt auto-renewal..."
 service cron start
 
+# Optionally start DHCPv6 client to obtain a global IPv6 address
+if [ "${ENABLE_DHCPV6:-false}" = "true" ]; then
+    echo "ENABLE_DHCPV6 is enabled. Starting DHCPv6 client..."
+    ifaces_to_configure="${DHCPV6_IFACE:-}"
+    if [ -z "$ifaces_to_configure" ]; then
+        # Fallback: try all non-loopback interfaces
+        ifaces_to_configure=$(ls /sys/class/net | grep -v '^lo$' || true)
+    fi
+    for iface in $ifaces_to_configure; do
+        echo "Requesting DHCPv6 lease on interface $iface ..."
+        dhclient -6 -nw -v "$iface" || true
+    done
+fi
+
 # ServerName setzen falls nicht vorhanden
 if ! grep -q "^ServerName" /etc/apache2/apache2.conf; then
     echo "ServerName localhost" >> /etc/apache2/apache2.conf


### PR DESCRIPTION
Configure container to obtain Global Unicast IPv6 (GUA) from router via an existing macvlan network.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9c9d375-cd05-43a0-9989-4f2cf9497cd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9c9d375-cd05-43a0-9989-4f2cf9497cd1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

