### PR TITLE
Update base image and check ipv6 readiness

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Basis-Image: Ubuntu 22.04 LTS (minimal)
-FROM ubuntu:22.04
+# Basis-Image: Ubuntu 24.04 LTS (minimal)
+FROM ubuntu:24.04
 
 # Environment Variables
 ENV DEBIAN_FRONTEND=noninteractive

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Apache2 Reverse Proxy mit Let's Encrypt
 
-Dieses Docker-Image bietet einen Apache2 Reverse Proxy basierend auf Ubuntu 22.04 LTS mit integrierter Let's Encrypt Unterstützung.
+Dieses Docker-Image bietet einen Apache2 Reverse Proxy basierend auf Ubuntu 24.04 LTS mit integrierter Let's Encrypt Unterstützung.
 
 ## Features
 
-- **Minimales Ubuntu 22.04 LTS** als Basis
+- **Minimales Ubuntu 24.04 LTS** als Basis
 - **Apache2** mit allen wichtigen Proxy-Modulen
 - **Let's Encrypt** Integration mit automatischer Zertifikatserneuerung
 - **Bind-Mount** Unterstützung für alle Konfigurationsdateien
@@ -169,7 +169,7 @@ Die Konfigurationen und Zertifikate bleiben durch die Bind-Mounts erhalten.
 
 ### Apache/Ubuntu Updates
 
-Das Basis-Image verwendet Ubuntu 22.04 LTS. Für Sicherheitsupdates:
+Das Basis-Image verwendet Ubuntu 24.04 LTS. Für Sicherheitsupdates:
 
 ```bash
 docker-compose pull


### PR DESCRIPTION
Update Docker base image to Ubuntu 24.04 and align README references.

---
<a href="https://cursor.com/background-agent?bcId=bc-496e8acf-c7e6-4266-8cc5-f189754d787a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-496e8acf-c7e6-4266-8cc5-f189754d787a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

