### PR TITLE
Automate dyndns config and speed up cron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -49,6 +49,10 @@ RUN mkdir -p /opt/defaults/apache2 \
     && cp -a /etc/apache2/mods-available /opt/defaults/apache2/ \
     && cp -a /etc/apache2/mods-enabled /opt/defaults/apache2/
 
+# Defaults der DynDNS-Konfiguration bereitstellen
+RUN mkdir -p /opt/defaults/dyndns
+COPY dyndns-config/ /opt/defaults/dyndns/
+
 # Cron für Let's Encrypt Auto-Renewal
 RUN echo "0 0,12 * * * root certbot renew --quiet --no-self-upgrade --post-hook 'apache2ctl graceful'" > /etc/cron.d/certbot-renew \
     && chmod 0644 /etc/cron.d/certbot-renew

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,8 +27,8 @@ services:
       # Webroot für Let's Encrypt Challenge (falls benötigt)
       - ./webroot:/var/www/html
       
-      # DynDNS Konfiguration (optional)
-      - ./dyndns-config:/etc/dyndns:ro
+      # DynDNS Konfiguration (optional, beschreibbar für automatisches Seeding)
+      - ./dyndns-config:/etc/dyndns
     environment:
       - TZ=${TZ:-Europe/Berlin}
     networks:


### PR DESCRIPTION
Enable direct editing of DynDNS configuration via bind-mount and implement an effective 5-second update schedule.

The DynDNS configuration can now be directly edited in the bind-mounted volume, similar to Apache configurations, with `config.env` being seeded from an example if missing. Since cron does not support second-level granularity, the 5-second update interval is emulated by creating multiple cron entries with `sleep` offsets.

---
<a href="https://cursor.com/background-agent?bcId=bc-b12a06be-708f-4214-9256-871a0795872c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b12a06be-708f-4214-9256-871a0795872c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

