### PR TITLE
Update dyndns with domain list and placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,18 @@ CLOUDFLARE_PROXIED=false
 CLOUDFLARE_TTL=120
 ```
 
-- Custom (beliebige URL mit Platzhaltern `{IPV4}` / `{IPV6}`):
+- Custom (eine einzige URL mit Platzhaltern `{DOMAIN}`, `{PASSWORT}`, `{IPV4}`, `{IPV6}`):
 ```bash
 PROVIDER=custom
-CUSTOM_URL=https://dyn.example.com/update?host=app.example.com&ip={IPV4}&ipv6={IPV6}
+# Die URL darf Kommata enthalten
+CUSTOM_URL=https://dyn.example.com/update?d={DOMAIN},ip4={IPV4},ip6={IPV6},pw={PASSWORT}
+
+# Zu aktualisierende Domains (kommagetrennt)
+CUSTOM_DOMAINS=app.example.com, www.example.com
+
+# Passwort für den Dienst
+CUSTOM_PASSWORT=mein-super-passwort
+
 # Optional
 CUSTOM_METHOD=GET
 ```

--- a/dyndns-config/config.env.example
+++ b/dyndns-config/config.env.example
@@ -1,17 +1,19 @@
 # DynDNS Konfiguration (Custom-only)
 
-# Einzelne URL mit Platzhaltern {IPV4} und {IPV6}
-# CUSTOM_URL=https://dyn.example.com/update?host=app.example.com&ip={IPV4}&ipv6={IPV6}
+# Eine einzige Update-URL mit Platzhaltern {DOMAIN}, {PASSWORT}, {IPV4}, {IPV6}
+# Hinweis: Die URL DARF Kommata enthalten.
+# Beispiel:
+# CUSTOM_URL=https://dyn.example.com/update?d={DOMAIN},ip4={IPV4},ip6={IPV6},pw={PASSWORT}
 
-# Oder mehrere URLs kommagetrennt (ersetzt jeweils {IPV4}/{IPV6})
-# Hinweis: Keine Anführungszeichen, Leerzeichen optional
-# CUSTOM_URLS=https://dyn1.example.com/update?host=a.example.com&ip={IPV4}, https://dyn2.example.com/update?host=b.example.com&ipv6={IPV6}
+# Kommagetrennte Liste der zu aktualisierenden Domains
+# Beispiel:
+# CUSTOM_DOMAINS=app.example.com, www.example.com, api.example.com
 
-# Optional: Ziel-Hosts für DNS-Vorprüfung (kommagetrennt, korrespondiert zu CUSTOM_URLS)
-# Falls leer, wird versucht, den Host aus dem Query-String zu lesen (host, hostname, name, domain, record, fqdn)
-# CUSTOM_HOSTS=a.example.com, b.example.com
+# Passwort (wird in {PASSWORT} eingesetzt)
+# Beispiel:
+# CUSTOM_PASSWORT=mein-super-passwort
 
-# Optional
+# Optional: HTTP-Methode (GET|POST), Standard GET
 # CUSTOM_METHOD=GET
 
 # --- Optional ---


### PR DESCRIPTION
Refactor the DynDNS custom provider to use a single URL template with domain and password placeholders for multiple domains.

The previous implementation lacked a domain list and specific domain/password placeholders, and could be ambiguous with commas. This change centralizes the update logic, enables iteration over a user-defined domain list, and introduces flexible placeholders, including support for commas within the update URL.

---
<a href="https://cursor.com/background-agent?bcId=bc-7207f95c-7b9c-4dc1-bee5-d0f787e7cdf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7207f95c-7b9c-4dc1-bee5-d0f787e7cdf6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

